### PR TITLE
fix: improve order creation and retrieval in the MercadoPago payment …

### DIFF
--- a/src/Helpers/Ipn.php
+++ b/src/Helpers/Ipn.php
@@ -108,6 +108,18 @@ class Ipn
                 // Try to find the order, but don't fail if not found (could be test data)
                 $order = $this->orderRepository->find($orderId);
 
+                if (! $order) {
+                    // Fallback: si la referencia era el id del carrito y la orden se creó luego con otro ID (incremental)
+                    // intentar localizar por campo cart_id si existe.
+                    try {
+                        if (method_exists($this->orderRepository->model, 'where')) {
+                            $order = $this->orderRepository->model::where('cart_id', $orderId)->first();
+                        }
+                    } catch (\Throwable $e) {
+                        // Ignorar
+                    }
+                }
+
                 if ($order) {
                     Log::info("MercadoPago IPN: Processing payment {$paymentId} for order {$orderId} with status {$payment->status}");
 

--- a/src/Payment/Standard.php
+++ b/src/Payment/Standard.php
@@ -157,7 +157,8 @@ class Standard extends MercadoPago
                     'pending' => route('mercadopago.standard.pending')
                 ],
                 'auto_return' => 'approved',
-                'external_reference' => (string) $cart->id,
+                // External reference debe apuntar a la orden (si ya fue creada) para que el IPN la localice
+                'external_reference' => (string) (session()->get('order_id') ?? $cart->id),
                 'payment_methods' => [
                     'excluded_payment_methods' => [],
                     'excluded_payment_types' => [],


### PR DESCRIPTION
This pull request introduces improvements to the MercadoPago payment flow, focusing on more robust order creation and retrieval throughout the checkout process. The main goal is to ensure orders are reliably created and referenced, even in edge cases where users do not return to the site after payment or when order IDs change. The most important changes are grouped below:

**Order Creation and Session Handling**

* In `StandardController.php`, the `redirect()` method now proactively creates the order before redirecting the user away from the site, storing the order ID in the session to prevent order loss if the user doesn't return.
* The `success()` method in `StandardController.php` first tries to reuse the order created during `redirect()`, and includes a fallback to create the order if it doesn't exist, ensuring legacy flows are supported and errors are logged.

**Order Lookup Improvements**

* In `Ipn.php`, the IPN processing logic now attempts to locate an order by `cart_id` if the standard order lookup fails, accommodating cases where the external reference was the cart ID and the order was created later with a different ID.

**Payment Preference and Reference Updates**

* In `Standard.php`, the payment preference's `external_reference` is set to the order ID from the session if available, otherwise falling back to the cart ID, improving IPN reliability.

**Cart Management**

* Cart deactivation in the `success()` method is now wrapped in a try/catch block to gracefully handle any errors, ensuring the checkout flow continues smoothly.…flow; handle external references properly